### PR TITLE
Upgrade com.fasterxml.jackson.core:jackson-databind to version 2.9.5 to avoid Vulnerable

### DIFF
--- a/starter-parent/pom.xml
+++ b/starter-parent/pom.xml
@@ -21,7 +21,7 @@
         <mapstruct.version>1.2.0.Final</mapstruct.version>
         <java.version>1.8</java.version>
         <spring-cloud-netflix.version>0.2.0.RELEASE</spring-cloud-netflix.version>
-        <jackson.version>2.9.3</jackson.version>
+        <jackson.version>2.9.5</jackson.version>
     </properties>
 
     <dependencies>


### PR DESCRIPTION
Fix security alerted following the report:
 https://nvd.nist.gov/vuln/detail/CVE-2018-7489